### PR TITLE
feat: add qa tag functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/strange-developer/test-utilities.svg?branch=master)](https://travis-ci.org/strange-developer/test-utilities) [![Coverage Status](https://coveralls.io/repos/github/strange-developer/test-utilities/badge.svg)](https://coveralls.io/github/strange-developer/test-utilities)
 
-A collection of test utilities for web applications. Currently only one function exists :)
+A collection of test utilities for web applications.
 
 ### select(qaTag: string): string
 
@@ -11,3 +11,15 @@ Takes in a string argument of your qa selector and returns a CSS selector.
 Example return value:
 
 `[data-qa="get-react-component__works"]`
+
+### qa(qaTag: string): object
+
+Takes in a string argument of your qa tag and returns an object to add to your React component.
+
+Example return value:
+
+`{ 'data-qa': 'get-react-component__works' }`
+
+Example usage:
+
+`<SomeComponent {...qa('get-react-component__works')} />`

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-// eslint-disable-next-line import/prefer-default-export
 export { default as select } from './qa-selector';
+export { default as qa } from './qa-tag';

--- a/src/qa-tag/index.js
+++ b/src/qa-tag/index.js
@@ -1,0 +1,1 @@
+export default qaTag => ({ 'data-qa': qaTag });

--- a/test/qa-tag/index.test.js
+++ b/test/qa-tag/index.test.js
@@ -1,0 +1,5 @@
+import qa from '../../src/qa-tag';
+
+test('qa-selector sets the qa tag', () => {
+  expect(qa('get-react-component__works')).toEqual({ 'data-qa': 'get-react-component__works' });
+});


### PR DESCRIPTION
add a `qa` method that returns an object used adding to React components.

---

The reason I think this is useful, is that now the _selector_ and the _creator_ are guaranteed to share the same name.